### PR TITLE
Fix Broken URL

### DIFF
--- a/content/platform/developer_guide/obbject.mdx
+++ b/content/platform/developer_guide/obbject.mdx
@@ -185,4 +185,4 @@ When a charting extension is installed, this method will display the chart if it
 
 OBBject extensions registers an accessor in each OBBject that is returned when a command is executed.
 
-This [page](platform/user_guide/add_obbject_extension) details the process for extending the OBBject class.
+This [page](/platform/user_guides/add_obbject_extension) details the process for extending the OBBject class.


### PR DESCRIPTION
Adds a "/" at the beginning so it registers the home path, and `user_guide` --> `user_guides`.