### PR TITLE
[BugFix] Platform Markdown Script - Ensure Reference & Data Model Table Cells Don't Create New Lines.

### DIFF
--- a/content/platform/developer_guide/documentation_development.mdx
+++ b/content/platform/developer_guide/documentation_development.mdx
@@ -15,37 +15,47 @@ import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 <HeadTitle title="Documentation - Development | OpenBB Platform Docs" />
 
 
-The documentation and packages are kept in the `/website` folder, at the base of the repository. Navigate there to install the dependencies and start the development server.
+The documentation and packages are kept in a separate repository. Clone the repo with the URL below.
 
-### Generate Markdown Files
+## Installation
 
-Markdown files for the Reference and Data Models pages need to be generated.
-This will generate content based on what is actually installed and contained locally, so it may appear different than what is on this website.
+Clone the repo and then navigate into the project folder.
 
-Open a terminal command line to the `/OpenBBTerminal/website` folder, then enter:
-
-```bash
-python generate_platform_v4_markdown.py
+```sh
+git clone https://github.com/OpenBB-finance/openbb-docs.git
 ```
+
+Packages should be installed within your OpenBB Platform Python environment. 
 
 ### Node.js
 
 - [Node.js](https://nodejs.org/en/) >= 16.13.0
   To check if Node.js installed, run this command:
 
-```bash
+```sh
 node --version # should be v16.13.0 or higher
 ```
 
-#### Install Dependencies
+### Install Dependencies
 
-```bash
+```sh
 npm install
+```
+
+### Generate Markdown Files
+
+Markdown files for the Reference and Data Models pages need to be generated.
+This will generate content based on what is actually installed and contained locally, so it may appear different than what is on this website.
+
+Run the command below from the root of the repository.
+
+```sh
+python scripts/generate_platform_markdown.py
 ```
 
 #### Start Development Server
 
-```bash
+```sh
 npm start
 ```
 
@@ -55,7 +65,7 @@ Most changes are reflected live without having to restart the server.
 
 #### Build
 
-```bash
+```sh
 npm run build
 ```
 

--- a/scripts/generate_platform_markdown.py
+++ b/scripts/generate_platform_markdown.py
@@ -365,7 +365,7 @@ def generate_reference_index_files(reference_content: Dict[str, str]) -> None:
         path: Path, parent_label: str = "Reference", position: int = 5
     ):
         # Check for sub-directories and markdown files in the current directory
-        sub_dirs = [d for d in path.iterdir() if d.is_dir()]
+        sub_dirs = sorted([d for d in path.iterdir() if d.is_dir()])
         markdown_files = [
             f for f in path.iterdir() if f.is_file() and f.suffix == ".md"
         ]
@@ -446,8 +446,9 @@ def generate_reference_top_level_index() -> None:
     """Generate the top-level index.mdx file for the reference directory."""
 
     # Get the sub-directories in the reference directory
-    reference_dirs = [d for d in PLATFORM_REFERENCE_PATH.iterdir() if d.is_dir()]
-    reference_dirs.sort()
+    reference_dirs = [
+        d for d in sorted(PLATFORM_REFERENCE_PATH.iterdir()) if d.is_dir()
+    ]
     reference_cards_content = ""
 
     for dir_path in reference_dirs:

--- a/scripts/generate_platform_markdown.py
+++ b/scripts/generate_platform_markdown.py
@@ -179,6 +179,30 @@ def create_reference_markdown_tabular_section(
         # A `|` is added at the start and end of the row to create the table cell.
         rows = "\n".join([f"| {' | '.join(map(str, p.values()))} |" for p in filtered])
 
+        def sanitize_rows(content):
+            """Sanitize the rows to ensure that the table is rendered correctly."""
+            lines = content.split("\n")
+            processed_lines = []
+            current_line = ""
+
+            for line in lines:
+                if line.startswith("|"):
+                    if current_line:
+                        processed_lines.append(current_line)
+                    current_line = line
+                else:
+                    if current_line.endswith("."):
+                        current_line += " " + line.strip()
+                    else:
+                        current_line += "; " + line.strip()
+
+            if current_line:
+                processed_lines.append(current_line)
+
+            return "\n".join(processed_lines)
+
+        rows = sanitize_rows(rows)
+
         if heading == "Parameters":
             tables_list.append(
                 f"\n<TabItem value='{provider}' label='{provider}'>\n\n"


### PR DESCRIPTION
The title summarizes it. This fixes an issue rendering the params tables where the content from the docstring is a multiline string. This puts it all on the same line with a semi-colon between list-like items.

After:

![Screenshot 2024-09-06 at 11 39 02 AM](https://github.com/user-attachments/assets/22546e27-1632-40f9-9d24-b7a4d02fb4cc)

This also updates the documentation section of the Platform docs to reflect the new repository location.