### PR TITLE
Add widget parameter positioning documentation and enhance widgets.json reference

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,1 +1,0 @@
-# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,2 +1,1 @@
 # Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
-content/

--- a/content/workspace/data-widgets/omni.md
+++ b/content/workspace/data-widgets/omni.md
@@ -82,7 +82,6 @@ class OmniWidgetResponse(BaseModel):
 })
 @app.post("/omni-widget")
 async def get_omni_widget(
-    search: str = Query(default="search"),
     data: str | dict = Body(...)
 ):
     if isinstance(data, str):
@@ -173,7 +172,6 @@ This example demonstrates how to add citation support to your Omni widget, which
 })
 @app.post("/omni-widget-citations")
 async def get_omni_widget_with_citations(
-    search: str = Query(default=""),
     data: str | dict = Body(...)
 ):
     if isinstance(data, str):
@@ -246,7 +244,6 @@ Unlike other widget types that use GET requests, the Omni widget uses POST reque
 ```python
 @app.post("/omni-widget")  # Note: POST, not GET
 async def omni_endpoint(
-    search: str = Query(default=""),  # Query parameters still available
     data: str | dict = Body(...)      # Main parameters in request body
 ):
     # Handle both string and dict formats

--- a/content/workspace/data-widgets/omni.md
+++ b/content/workspace/data-widgets/omni.md
@@ -1,0 +1,337 @@
+---
+title: Omni
+sidebar_position: 19
+description: Learn how to create versatile Omni widgets for OpenBB Workspace that can dynamically return different content types based on input parameters.
+keywords:
+- omni widget
+- dynamic content
+- POST request
+- multi-format output
+- widget configuration
+- citations
+- flexible widgets
+- OpenBB Workspace
+- widget development
+---
+
+import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
+
+<HeadTitle title="Omni Widget | OpenBB Workspace Docs" />
+
+The Omni widget is a versatile widget type that can dynamically return different content formats (text/markdown, tables, or charts) based on input parameters. Unlike other widgets that use GET requests, the Omni widget uses POST requests and passes all parameters in the request body.
+
+## Key Features
+
+- **Dynamic Output Control**: Can return different content types (text, table, chart) based on parameters
+- **POST Request Method**: Uses POST instead of GET, with parameters passed in the request body
+- **Citation Support**: Built-in support for adding citations and source information
+- **Flexible Parameter Handling**: All widget parameters are passed in the POST data
+
+## Basic Omni Widget
+
+A widget that demonstrates the versatility of the Omni widget by returning different content types based on the `type` parameter.
+
+<img className="pro-border-gradient" width="800" alt="Omni Widget Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/omni-widget.png" />
+
+```python
+from pydantic import BaseModel, Field
+from typing import Any, List, Literal
+from uuid import UUID
+from fastapi import FastAPI, Body, Query
+import json
+
+class DataFormat(BaseModel):
+    data_type: str
+    parse_as: Literal["text", "table", "chart"]
+
+class OmniWidgetResponse(BaseModel):
+    content: Any
+    data_format: DataFormat
+    extra_citations: list[ExtraCitation] | None = Field(default_factory=list)
+    citable: bool = Field(default=True)
+
+@register_widget({
+    "name": "Omni Widget Example",
+    "description": "A versatile omni widget that can display multiple types of content",
+    "category": "General",
+    "type": "omni",
+    "endpoint": "omni-widget",
+    "params": [
+        {
+            "paramName": "prompt",
+            "type": "text",
+            "description": "The prompt to send to the LLM to make queries or ask questions.",
+            "label": "Prompt",
+            "show": False
+        },
+        {
+            "paramName": "type",
+            "type": "text",
+            "description": "Type of content to return",
+            "label": "Content Type",
+            "show": True,
+            "options": [
+                {"value": "markdown", "label": "Markdown"},
+                {"value": "chart", "label": "Chart"},
+                {"value": "table", "label": "Table"}
+            ]
+        }
+    ],
+    "gridData": {"w": 30, "h": 12}
+})
+@app.post("/omni-widget")
+async def get_omni_widget(
+    search: str = Query(default="search"),
+    data: str | dict = Body(...)
+):
+    if isinstance(data, str):
+        data = json.loads(data)
+
+    # Return table format
+    if data.get("type") == "table":
+        content = [
+            {"col1": "value1", "col2": "value2", "col3": "value3", "col4": "value4"},
+            {"col1": "value5", "col2": "value6", "col3": "value7", "col4": "value8"},
+            {"col1": "value9", "col2": "value10", "col3": "value11", "col4": "value12"},
+        ]
+        
+        return OmniWidgetResponse(
+            content=content,
+            data_format=DataFormat(data_type="object", parse_as="table")
+        )
+
+    # Return chart format
+    if data.get("type") == "chart":
+        content = {
+            "data": [
+                {"x": [1, 2, 3], "y": [4, 1, 2], "type": "bar"},
+                {"x": [1, 2, 3], "y": [2, 4, 5], "type": "bar"},
+                {"x": [1, 2, 3], "y": [2, 3, 6], "type": "bar"},
+            ],
+            "layout": {
+                "title": "Dynamic Chart",
+                "template": "plotly_dark"
+            },
+        }
+        
+        return OmniWidgetResponse(
+            content=content,
+            data_format=DataFormat(data_type="object", parse_as="chart")
+        )
+
+    # Return markdown format (default)
+    content = f"""### Dynamic Omni Widget Response
+
+**Input Parameters:**
+- **Search Query:** `{search}`
+- **Content Type:** `{data.get('type', 'markdown')}`
+- **Prompt:** `{data.get('prompt', 'No prompt provided')}`
+
+#### Raw Data:
+    {json.dumps(data, indent=2)}        
+
+    """
+        
+    return OmniWidgetResponse(
+        content=content,
+        data_format=DataFormat(data_type="object", parse_as="text")
+    )
+```
+
+## Omni Widget with Citations
+
+This example demonstrates how to add citation support to your Omni widget, which is useful for tracking data sources and providing transparency about the information displayed. These citations are automatically added to the response if the `citable` parameter is set to `True`. This is shown in the example below and returned when they user is interacting with the widget through an agent.
+
+<img className="pro-border-gradient" width="800" alt="Omni Widget with Citations Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/omni-widget+with+citation.png" />
+
+```python
+@register_widget({
+    "name": "Omni Widget with Citations",
+    "description": "An omni widget that includes citation information",
+    "category": "General",
+    "type": "omni",
+    "endpoint": "omni-widget-citations",
+    "params": [
+        {
+            "paramName": "prompt",
+            "type": "text",
+            "description": "The prompt to send to the LLM to make queries or ask questions.",
+            "label": "Prompt",
+            "show": True
+        },
+        {
+            "paramName": "include_metadata",
+            "type": "boolean",
+            "description": "Include metadata in response",
+            "label": "Include Metadata",
+            "show": True,
+            "value": True
+        }
+    ],
+    "gridData": {"w": 30, "h": 15}
+})
+@app.post("/omni-widget-citations")
+async def get_omni_widget_with_citations(
+    search: str = Query(default=""),
+    data: str | dict = Body(...)
+):
+    if isinstance(data, str):
+        data = json.loads(data)
+
+    # Create citation information
+    source_info = SourceInfo(
+        type="widget",
+        widget_id="omni_widget_citations",
+        origin="custom_backend",
+        name="Omni Widget with Citations",
+        description="Example widget demonstrating citation functionality",
+        metadata={
+            "prompt": data.get("prompt", ""),
+            "search_term": search,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "data_source": "Custom API"
+        }
+    )
+    
+    extra_citation = ExtraCitation(
+        source_info=source_info,
+        details=[
+            {
+                "Source": "Custom Backend API",
+                "Prompt": data.get("prompt", ""),
+                "Search": search,
+                "Metadata_Included": data.get("include_metadata", False),
+                "Response_Type": "Dynamic Content"
+            }
+        ]
+    )
+
+    # Generate content based on parameters
+    content = f"""# Query Results
+
+**Search Query:** {search}
+**User Prompt:** {data.get('prompt', 'No prompt provided')}
+
+## Results
+This is dynamically generated content based on your input parameters.
+
+### Metadata
+"""
+    
+    if data.get("include_metadata"):
+        content += f"""
+- **Widget ID:** omni_widget_citations
+- **Timestamp:** 2024-01-01T00:00:00Z
+- **Data Source:** Custom API
+- **Parameters:** {json.dumps(data, indent=2)}
+"""
+    else:
+        content += "Metadata hidden (set 'Include Metadata' to true to view)"
+
+    return OmniWidgetResponse(
+        content=content,
+        data_format=DataFormat(data_type="object", parse_as="text"),
+        extra_citations=[extra_citation],
+        citable=True
+    )
+```
+
+## Important Implementation Notes
+
+### POST Request Method
+
+Unlike other widget types that use GET requests, the Omni widget uses POST requests. This allows for more complex parameter handling and larger payloads:
+
+```python
+@app.post("/omni-widget")  # Note: POST, not GET
+async def omni_endpoint(
+    search: str = Query(default=""),  # Query parameters still available
+    data: str | dict = Body(...)      # Main parameters in request body
+):
+    # Handle both string and dict formats
+    if isinstance(data, str):
+        data = json.loads(data)
+    
+    # All widget parameters are available in the 'data' object
+    param_value = data.get("paramName")
+```
+
+### Dynamic Output Control
+
+The Omni widget can return different content types based on the parse_as field in the DataFormat:
+
+"text": For markdown/text content
+"table": For tabular data (list of dictionaries)
+"chart": For Plotly chart objects
+
+```python
+# Text/Markdown output
+return OmniWidgetResponse(
+    content="# Markdown content",
+    data_format=DataFormat(data_type="object", parse_as="text")
+)
+```
+
+```python
+# Table output
+return OmniWidgetResponse(
+    content=[{"col1": "val1", "col2": "val2"}],
+    data_format=DataFormat(data_type="object", parse_as="table")
+)   
+```
+
+```python
+# Chart output
+return OmniWidgetResponse(
+    content={"data": [...], "layout": {...}},
+    data_format=DataFormat(data_type="object", parse_as="chart")
+)
+```
+
+### Parameter Handling
+
+All widget parameters defined in the widget configuration are passed in the POST request body, and the `prompt` parameter is required:
+
+```json
+{
+  "params": [
+    {
+        // Required parameter for the LLM to make queries or ask questions
+        "paramName": "prompt",
+        "type": "text",
+        "description": "The prompt to send to the LLM to make queries or ask questions.",
+        "label": "Prompt",
+        "show": False
+    }
+    {
+        "paramName": "user_input",
+        "type": "text",
+        "label": "User Input"
+    },
+    {
+        "paramName": "option_select",
+        "type": "text",
+        "options": [...]
+    }
+  ]
+}
+```
+
+These parameters are accessible in your endpoint:
+
+```python
+@app.post("/omni-widget")
+async def omni_endpoint(data: dict = Body(...)):
+    user_input = data.get("user_input")
+    selected_option = data.get("option_select")
+    prompt = data.get("prompt")
+    # Process parameters...
+```
+
+## Use Cases
+
+The Omni widget is particularly useful for:
+
+- AI/LLM Integration: Dynamic content generation based on user prompts
+- Multi-format Data Display: Single endpoint that can return different visualizations
+- Citation-heavy Applications: Research tools that need to track data sources

--- a/content/workspace/data-widgets/omni.md
+++ b/content/workspace/data-widgets/omni.md
@@ -45,6 +45,10 @@ class DataFormat(BaseModel):
     data_type: str
     parse_as: Literal["text", "table", "chart"]
 
+class ExtraCitation(BaseModel):
+    source_info: SourceInfo | None = Field(default=None)
+    details: List[dict] | None = Field(default=None)
+
 class OmniWidgetResponse(BaseModel):
     content: Any
     data_format: DataFormat

--- a/content/workspace/data-widgets/omni.md
+++ b/content/workspace/data-widgets/omni.md
@@ -18,18 +18,19 @@ import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
 <HeadTitle title="Omni Widget | OpenBB Workspace Docs" />
 
-The Omni widget is a versatile widget type that can dynamically return different content formats (text/markdown, tables, or charts) based on input parameters. Unlike other widgets that use GET requests, the Omni widget uses POST requests and passes all parameters in the request body.
+The Omni widget is a versatile widget type that can dynamically return different content formats (markdown, tables, or charts). Unlike other widgets that use GET requests, the Omni widget uses POST requests and passes all parameters in the request body. This widget requires the `prompt` parameter to be passed in the params section of the widget configuration.
 
 ## Key Features
 
-- **Dynamic Output Control**: Can return different content types (text, table, chart) based on parameters
+- **Dynamic Output Control**: Can return different content types (text, table, chart)
+- **Create Widgets from Responses**: Create widgets directly from the response types returned by the backend.
 - **POST Request Method**: Uses POST instead of GET, with parameters passed in the request body
 - **Citation Support**: Built-in support for adding citations and source information
 - **Flexible Parameter Handling**: All widget parameters are passed in the POST data
 
 ## Basic Omni Widget
 
-A widget that demonstrates the versatility of the Omni widget by returning different content types based on the `type` parameter.
+Below is an example of a basic Omni widget that demonstrates the versatility by returning different content types based on the `type` parameter. In a real world example you might choose to dynamically return different content types based on your backend logic.
 
 <img className="pro-border-gradient" width="800" alt="Omni Widget Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/omni-widget.png" />
 
@@ -140,7 +141,7 @@ async def get_omni_widget(
 
 ## Omni Widget with Citations
 
-This example demonstrates how to add citation support to your Omni widget, which is useful for tracking data sources and providing transparency about the information displayed. These citations are automatically added to the response if the `citable` parameter is set to `True`. This is shown in the example below and returned when they user is interacting with the widget through an agent.
+This example demonstrates how to add citation support to your Omni widget, which is useful when you want to use the widget in conjunction with an agent. The citations are added to the response if the `citable` parameter is set to `True`. This is shown in the example below and returned when the user is interacting with the widget through an agent.
 
 <img className="pro-border-gradient" width="800" alt="Omni Widget with Citations Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/omni-widget+with+citation.png" />
 
@@ -334,4 +335,4 @@ The Omni widget is particularly useful for:
 
 - AI/LLM Integration: Dynamic content generation based on user prompts
 - Multi-format Data Display: Single endpoint that can return different visualizations
-- Citation-heavy Applications: Research tools that need to track data sources
+- Citation-heavy Applications: Research tools that need to track data sources.

--- a/content/workspace/widget-configuration/render-functions.md
+++ b/content/workspace/widget-configuration/render-functions.md
@@ -27,7 +27,6 @@ In the `widgets.json` configuration, you can specify render functions to customi
 | `columnColor` | Changes the color of a column based on specified rules |
 | `showCellChange` | Highlights cells when their values change via WebSocket updates. Only used with the [Live Grid Widget](/content/workspace/data-widgets/live-grid.md) |
 
-
 ### Render Function Parameters
 
 | Parameter | Type | Description |
@@ -196,3 +195,7 @@ The hover card example would use the below data to display the hover card.
 
 - You can pass a simple configuration to get a hover card with default settings, excluding the title and value.
 - The `hoverCard` render function allows for markdown customization, providing flexibility in how information is displayed.
+
+### Prefix and Suffix
+
+The `prefix` and `suffix` parameters can also be used in the `columnsDefs` to add a prefix or suffix to the column values. [See the widgets-json-reference](/content/workspace/widgets-json-reference.md) for more information.

--- a/content/workspace/widget-configuration/render-functions.md
+++ b/content/workspace/widget-configuration/render-functions.md
@@ -31,10 +31,18 @@ In the `widgets.json` configuration, you can specify render functions to customi
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **actionType** | `string` | Specifies the action type for the render function |
+| **actionType** | `string` | Specifies the action type for the render function (`"openUrl"`, `"openModal"`, `"openWidget"`, `"groupBy"`, `"sendToAgent"`) |
 | **colorValueKey** | `string` | Specifies which field to use for determining the color when showing cell changes |
 | **hoverCardData** | `array of strings` | Specifies columns to show in the hover card |
 | **colorRules** | `array of objects` | An array of rules for conditional coloring |
+| **sendToAgent** | `object` | Configuration for sending data to an AI agent |
+
+### Send to Agent Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **markdown** | `string` | Markdown content to send to the agent, supports template variables from row data |
+| **agentId** | `string` | (Optional) Specific agent ID to send the message to |
 
 ### Color Rules Parameters
 
@@ -42,7 +50,7 @@ In the `widgets.json` configuration, you can specify render functions to customi
 |-----------|------|-------------|---------|
 | **condition** | `string` | The condition for applying the color | `"eq"`, `"ne"`, `"gt"`, `"lt"`, `"gte"`, `"lte"`, `"between"` |
 | **value** | `number` | The value for the condition | - |
-| **range** | `object` | An object specifying `min` and `max` values for the condition | `{min: number, max: number}` |
+| **range** | `object` | An object specifying `min` and `max` values for the between condition | `{min: number, max: number}` |
 | **color** | `string` | The color to apply | Hex code or `"green"`, `"red"`, `"blue"` |
 | **fill** | `boolean` | Indicates if the color should fill the cell | `true`/`false` |
 
@@ -199,3 +207,47 @@ The hover card example would use the below data to display the hover card.
 ### Prefix and Suffix
 
 The `prefix` and `suffix` parameters can also be used in the `columnsDefs` to add a prefix or suffix to the column values. [See the widgets-json-reference](/content/workspace/widgets-json-reference.md) for more information.
+
+### Send to Agent
+
+The `sendToAgent` action type allows users to click on table cells to send contextual data directly to an AI agent for analysis. This is particularly useful for getting insights about specific data points or rows.
+
+```json
+{
+    ...
+    "columnsDefs": [
+        {
+            "field": "company",
+            "headerName": "Company",
+            "renderFn": "cellOnClick",
+            "renderFnParams": {
+                "actionType": "sendToAgent",
+                "sendToAgent": {
+                    "markdown": "Please analyze the company **{company}** with the following details:\n\n- **Revenue:** ${revenue}M\n- **Growth Rate:** {growth_rate}%\n- **Market Cap:** ${market_cap}B\n- **Sector:** {sector}\n\nProvide insights on the company's financial performance, growth prospects, and market position."
+                }
+            }
+        },
+        {
+            "field": "revenue",
+            "headerName": "Revenue (M)",
+            "renderFn": "cellOnClick",
+            "renderFnParams": {
+                "actionType": "sendToAgent",
+                "sendToAgent": {
+                    "markdown": "Analyze the revenue figure of **${revenue}M** for {company}. How does this compare to industry standards in the {sector} sector?",
+                    "agentId": "financial-analyst-agent"
+                }
+            }
+        }
+    ]
+}
+```
+
+#### Template Variables
+
+The `markdown` content in `sendToAgent` supports template variables using curly braces `{}`. You can reference any field from the row data:
+
+- `{company}` - References the company field value
+- `{revenue}` - References the revenue field value  
+- `{growth_rate}` - References the growth_rate field value
+- And so on for any field in your data

--- a/content/workspace/widget-parameters/parameter-positioning.md
+++ b/content/workspace/widget-parameters/parameter-positioning.md
@@ -1,6 +1,6 @@
 ---
 title: Parameter Positioning
-sidebar_position: 30
+sidebar_position: 19
 description: Learn how to control the layout and positioning of widget parameters in OpenBB Workspace, including row positioning and parameter ordering
 keywords:
 - parameter positioning

--- a/content/workspace/widget-parameters/parameter-positioning.md
+++ b/content/workspace/widget-parameters/parameter-positioning.md
@@ -16,6 +16,8 @@ import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
 By default, widget parameters are displayed in a single row at the top of the widget. However, you can control the positioning and layout of parameters by organizing them into multiple rows and changing their order within those rows.
 
+<img className="pro-border-gradient" width="1000" alt="Parameter Grouping Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/markdown-organized-params.png" />
+
 ## Row Positioning
 
 To position parameters in different rows, you can structure the `params` array as a nested array where each sub-array represents a row of parameters.

--- a/content/workspace/widget-parameters/parameter-positioning.md
+++ b/content/workspace/widget-parameters/parameter-positioning.md
@@ -1,0 +1,204 @@
+---
+title: Parameter Positioning
+sidebar_position: 30
+description: Learn how to control the layout and positioning of widget parameters in OpenBB Workspace, including row positioning and parameter ordering
+keywords:
+- parameter positioning
+- parameter layout
+- parameter rows
+- widget parameters
+- parameter ordering
+---
+
+import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
+
+<HeadTitle title="Parameter Positioning | OpenBB Workspace Docs" />
+
+By default, widget parameters are displayed in a single row at the top of the widget. However, you can control the positioning and layout of parameters by organizing them into multiple rows and changing their order within those rows.
+
+## Row Positioning
+
+To position parameters in different rows, you can structure the `params` array as a nested array where each sub-array represents a row of parameters.
+
+### Single Row (Default)
+
+```python
+"params": [
+    {
+        "paramName": "param1",
+        "type": "text",
+        "value": "value1"
+    },
+    {
+        "paramName": "param2",
+        "type": "text",
+        "value": "value2"
+    }
+]
+```
+
+### Multiple Rows
+
+```python
+"params": [
+    [], # Empty first row
+    [ # Second row with parameters
+        {
+            "paramName": "param1",
+            "type": "text",
+            "value": "value1"
+        },
+        {
+            "paramName": "param2",
+            "type": "text",
+            "value": "value2"
+        }
+    ]
+]
+```
+
+## Complete Example
+
+Here's a comprehensive example showing how to position different types of parameters across multiple rows:
+
+```python
+@register_widget({
+    "name": "Moving Parameters Example",
+    "description": "Show example of moving parameter positions",
+    "endpoint": "moving_parameters_example",
+    "gridData": {"w": 20, "h": 9},
+    "type": "table",
+    "params": [
+        [],  # Empty first row - pushes all parameters to second row
+        [    # Second row with all parameters
+            {
+                "paramName": "datePicker1",
+                "value": "$currentDate-1d",
+                "label": "Param 1",
+                "description": "I'm a Date Picker!",
+                "type": "date"
+            },
+            {
+                "paramName": "textBox1",
+                "value": "Hello!",
+                "label": "Param 2",
+                "description": "I'm a text input box!",
+                "type": "text"
+            },
+            {
+                "paramName": "TrueFalse",
+                "value": True,
+                "label": "True/False",
+                "description": "I'm a True/False selector!",
+                "type": "boolean"
+            },
+            {
+                "paramName": "daysPicker1",
+                "value": "1",
+                "label": "Days",
+                "type": "text",
+                "multiSelect": True,
+                "description": "Number of days to look back",
+                "options": [
+                    {"value": "1", "label": "1"},
+                    {"value": "5", "label": "5"},
+                    {"value": "10", "label": "10"},
+                    {"value": "20", "label": "20"},
+                    {"value": "30", "label": "30"}
+                ]
+            }
+        ]
+    ]
+})
+@app.get("/moving_parameters_example")
+def moving_parameters_example(
+    datePicker1: str = None,
+    textBox1: str = None,
+    daysPicker1: str = "1",
+    TrueFalse: bool = True
+):
+    """Show example of how to move parameters - This will put them all on the second row of the widget"""
+    return {
+        "datePicker1": datePicker1,
+        "textBox1": textBox1,
+        "daysPicker1": daysPicker1.split(","),
+        "TrueFalse": TrueFalse
+    }
+```
+
+## Advanced Positioning Examples
+
+### Parameters Across Multiple Rows
+
+```python
+"params": [
+    [ # First row
+        {
+            "paramName": "symbol",
+            "type": "text",
+            "value": "AAPL",
+            "label": "Symbol"
+        }
+    ],
+    [ # Second row
+        {
+            "paramName": "start_date",
+            "type": "date",
+            "value": "$currentDate-30d",
+            "label": "Start Date"
+        },
+        {
+            "paramName": "end_date",
+            "type": "date",
+            "value": "$currentDate",
+            "label": "End Date"
+        }
+    ],
+    [ # Third row
+        {
+            "paramName": "show_volume",
+            "type": "boolean",
+            "value": True,
+            "label": "Show Volume"
+        }
+    ]
+]
+
+### Skipping Multiple Rows
+
+```python
+"params": [
+    [], # Skip first row
+    [], # Skip second row
+    [ # Parameters on third row
+    {
+        "paramName": "param1",
+        "type": "text",
+        "value": "value1"
+    }
+    ]
+]
+```
+
+## Parameter Ordering
+
+Within each row, parameters are displayed in the order they appear in the array. You can change the visual order by rearranging the parameter objects:
+
+```python
+# Original order: Date, Text, Boolean, Dropdown
+[
+    {"paramName": "date_param", "type": "date", ...},
+    {"paramName": "text_param", "type": "text", ...},
+    {"paramName": "bool_param", "type": "boolean", ...},
+    {"paramName": "dropdown_param", "type": "text", "options": [...], ...}
+]
+# Reordered: Boolean, Dropdown, Date, Text
+[
+    {"paramName": "bool_param", "type": "boolean", ...},
+    {"paramName": "dropdown_param", "type": "text", "options": [...], ...},
+    {"paramName": "date_param", "type": "date", ...},
+    {"paramName": "text_param", "type": "text", ...}
+]
+```
+
+In the above example, the parameters are displayed in the order: Date, Text, Boolean, Dropdown. Then, the parameters are reordered to: Boolean, Dropdown, Date, Text based on the order of the parameters in the array.

--- a/content/workspace/widget-parameters/text-input.md
+++ b/content/workspace/widget-parameters/text-input.md
@@ -16,6 +16,12 @@ import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
 A widget that includes a text input parameter allowing users to enter custom text. The entered text is passed to the widget as a parameter.
 
+There are two types of text input parameters:
+
+Simple text input and an editable text input.
+
+## Simple Text Input
+
 <img className="pro-border-gradient" width="800" alt="Text Input Parameter Example" src="https://openbb-cms.directus.app/assets/b126ba58-ff29-4923-b124-1a0314ad4842.png" />
 
 ```python
@@ -41,3 +47,36 @@ def markdown_widget_with_text_input(text_box: str):
     return f"""# Text Input
 Entered text: {text_box}
 """ 
+```
+
+
+## Editable Text Input
+
+<img className="pro-border-gradient" width="800" alt="Text Input Parameter Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/text-input-with-dd.png" />
+
+
+```python
+@register_widget({
+    "name": "Markdown Widget with Text Input",
+    "description": "A markdown widget with a text input parameter",
+    "endpoint": "markdown_widget_with_text_input",
+    "gridData": {"w": 16, "h": 6},
+    "type": "markdown",
+    "params": [
+        {
+            "paramName": "text_box",
+            "value": "var1,var2,var3",
+            "label": "Enter Text",
+            "description": "Type something to display",
+            "editable": true,
+            "type": "text"
+        }
+    ]
+})
+@app.get("/markdown_widget_with_text_input")
+def markdown_widget_with_text_input(text_box: str):
+    """Returns a markdown widget with text input parameter"""
+    return f"""# Text Input
+Entered text: {text_box}
+""" 
+```

--- a/content/workspace/widget-parameters/text-input.md
+++ b/content/workspace/widget-parameters/text-input.md
@@ -18,7 +18,7 @@ A widget that includes a text input parameter allowing users to enter custom tex
 
 There are two types of text input parameters:
 
-Simple text input and an editable text input.
+Simple text input and a multiple options text input.
 
 ## Simple Text Input
 
@@ -49,8 +49,7 @@ Entered text: {text_box}
 """ 
 ```
 
-
-## Editable Text Input
+## Multiple Options Text Input
 
 <img className="pro-border-gradient" width="800" alt="Text Input Parameter Example" src="https://openbb-assets.s3.us-east-1.amazonaws.com/docs/pro/text-input-with-dd.png" />
 
@@ -68,7 +67,7 @@ Entered text: {text_box}
             "value": "var1,var2,var3",
             "label": "Enter Text",
             "description": "Type something to display",
-            "editable": true,
+            "multiple": true,
             "type": "text"
         }
     ]

--- a/content/workspace/widgets-json-reference.md
+++ b/content/workspace/widgets-json-reference.md
@@ -100,6 +100,26 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
     _Example:_ `9`
     _Maximum value:_ `100`
 
+  - **minW**
+    _Type:_ `number`
+    Sets the minimum width of the widget in grid units.
+    _Example:_ `10`
+
+  - **minH**
+    _Type:_ `number`
+    Sets the minimum height of the widget in grid units.
+    _Example:_ `10`
+
+  - **maxW**
+    _Type:_ `number`
+    Sets the maximum width of the widget in grid units.
+    _Example:_ `40`
+
+  - **maxH**  
+    _Type:_ `number`
+    Sets the maximum height of the widget in grid units.
+    _Example:_ `100`
+
 - **data**
   _Type:_ object containing the following keys:
 
@@ -224,6 +244,16 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
         _Type:_ `string`
         Tooltip text for the column header.
         _Example:_ `"This is a tooltip"`
+
+      - **prefix**
+        _Type:_ `string`
+        Prefix to be added to the column header.
+        _Example:_ `"$"`
+
+      - **suffix**
+        _Type:_ `string`
+        Suffix to be added to the column header.
+        _Example:_ `"USD"`
 
 - **params**
   _Type:_ list of objects, each containing the following keys:

--- a/content/workspace/widgets-json-reference.md
+++ b/content/workspace/widgets-json-reference.md
@@ -212,7 +212,68 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
       - **renderFnParams**
         _Type:_ `object`
         Required if `renderFn` is used. Specifies the parameters for the render function.
-        _Example:_ `{"actionType": "groupBy"}`
+        _Example:_ `{"actionType": "sendToAgent", "sendToAgent": {"markdown": "Analyze **{company}** data"}}`
+
+        - **actionType**
+          _Type:_ `string`
+          Specifies the action type for the render function.
+          _Example:_ `"sendToAgent"`
+          _Possible values:_ `"groupBy"`, `"sendToAgent"`
+
+        - **groupByParamName**
+          _Type:_ `string`
+          Group by parameter for the render function.
+          _Example:_ `"symbol"`
+
+        - **colorValueKey**
+          _Type:_ `string`
+          Specifies which field to use for determining the color when showing cell changes.
+          _Example:_ `"Analyst"`
+
+        - **hoverCardData**
+          _Type:_ `array of strings`
+          Specifies columns to show in the hover card.
+          _Example:_ `["column1", "column2"]`
+
+        - **colorRules**
+          _Type:_ `array of objects`
+          An array of rules for conditional coloring.
+          _Example:_ `[{"condition": "gt", "value": 50, "color": "green", "fill": true}]`
+
+        - **hoverCard**
+          _Type:_ `object`
+          Hover card configuration.
+          Contains the following keys:
+
+          - **cellField**
+            _Type:_ `string`
+            Field to display on table cell.
+            _Example:_ `"value"`
+
+          - **title**
+            _Type:_ `string`
+            Title for the hover card.
+            _Example:_ `"Analyst Details"`
+
+          - **markdown**
+            _Type:_ `string`
+            Markdown content for the hover card.
+            _Example:_ `"### {value}\n- **Description:** {description}"`
+
+        - **sendToAgent**
+          _Type:_ `object`
+          Configuration for sending data to an AI agent.
+          Contains the following keys:
+
+          - **markdown**
+            _Type:_ `string`
+            Markdown content to send to the agent, supports template variables from row data using curly braces.
+            _Example:_ `"Please analyze the company **{company}** with revenue of ${revenue}M"`
+
+          - **agentId**
+            _Type:_ `string`
+            (Optional) Specific agent ID to send the message to.
+            _Example:_ `"financial-analyst-agent"`
 
       - **width**
         _Type:_ `number`

--- a/content/workspace/widgets-json-reference.md
+++ b/content/workspace/widgets-json-reference.md
@@ -161,6 +161,20 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
         _Example:_ `"column"`
         _Possible values:_ see [ChartView chart types](#chartview-chart-types)
 
+      - **cellRangeCols**
+        _Type:_ `object`
+        Defines the default column mappings for different chart types. Each key represents a chart type, and the value is an array of column names that specify the category and series columns for that chart type.
+        The array structure is: `[category, series1, series2, ...]` where:
+        - First element: The category column (x-axis)
+        - Remaining elements: The series columns (y-axis data)
+        _Example:_ 
+        ```json
+        "cellRangeCols": {
+          "line": ["ticker", "weight", "weight2"],
+          "column": ["date", "price", "volume"]
+        }
+        ```
+
       - **ignoreCellRange**
         _Type:_ `boolean`
         Ignores stored cell range for the chart.
@@ -443,7 +457,10 @@ Below is an example `widgets.json` with a single widget defined. This widget wil
                 "showAll": true,
                 "chartView": {
                     "enabled": true,
-                    "chartType": "column"
+                    "chartType": "column",
+                    "cellRangeCols" : {
+                        "line": ["ticker", "weight"]
+                    }
                 },
                 "columnsDefs": [
                     {

--- a/content/workspace/widgets-json-reference.md
+++ b/content/workspace/widgets-json-reference.md
@@ -327,6 +327,22 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
       The value for a dropdown option.
       _Example:_ `"option1"`
 
+    - **extraInfo**
+      _Type:_ `object`
+      Additional information to display for the dropdown option.
+      _Example:_ `{"description": "Technology Company", "rightOfDescription": "NASDAQ"}`
+
+      Contains the following keys:
+
+      - **description**
+        _Type:_ `string`
+        Additional descriptive text shown below the label.
+        _Example:_ `"Technology Company"`
+
+      - **rightOfDescription**
+        _Type:_ `string`
+        Text shown to the right of the description.
+        _Example:_ `"NASDAQ"`
 
 - **source**
   _Type:_ array of strings

--- a/content/workspace/widgets-json-reference.md
+++ b/content/workspace/widgets-json-reference.md
@@ -284,6 +284,11 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
     Endpoint to fetch options for the parameter.
     _Example:_ `"v1/test/values"`
 
+  - **editable**
+    _Type:_ `boolean`
+    If true, the parameter will be editable. Only used with the `text` type.
+    _Example:_ `true`
+
   - **optionsParams**
     _Type:_ `object`
     Parameters to pass to the options endpoint. You can use the parameter name from the `params` array to pass a value to the options endpoint.

--- a/content/workspace/widgets-json-reference.md
+++ b/content/workspace/widgets-json-reference.md
@@ -284,9 +284,9 @@ A `Widgets.json` table is a configuration structure with any of the named attrib
     Endpoint to fetch options for the parameter.
     _Example:_ `"v1/test/values"`
 
-  - **editable**
+  - **multiple**
     _Type:_ `boolean`
-    If true, the parameter will be editable. Only used with the `text` type.
+    If true, the parameter will be a dropdown with multiple selectable options that you can add add-hoc.
     _Example:_ `true`
 
   - **optionsParams**


### PR DESCRIPTION
- Introduced a new document on parameter positioning, detailing how to control layout and order of widget parameters.
- Expanded the widgets.json reference to include minW, minH, maxW, and maxH attributes for widget sizing.
- Added prefix and suffix parameters for column definitions in the widgets.json reference.
- Updated render functions documentation to include usage of prefix and suffix in column values.

TODO - @andrewkenreich 
- Add screenshots for parameter positioning (ensure that the [] for the first row is fixed)
- Update screenshot for the text field with dropdown to not have "n terms" and instead "<label> (3)". Note that if there's only one field, then it should just be the term itself.