### PR TITLE
Fix Path Redirect Text Replace

### DIFF
--- a/src/components/General/TerminalRedirect.tsx
+++ b/src/components/General/TerminalRedirect.tsx
@@ -4,13 +4,9 @@ import { useEffect } from "react";
 export default function TerminalRedirect() {
 	const { pathname } = useLocation();
 
+	const newPath = pathname
+		.replace(/^\/terminal(\/|$)/, "/workspace$1")
+		.replace(/^\/pro(\/|$)/, "/workspace$1");
 	// Handle other redirects with replace
-	return (
-		<Redirect
-			to={pathname
-				.replace("/terminal", "/workspace")
-				.replace("/pro", "/workspace")
-			}
-		/>
-	);
+	return <Redirect to={newPath} />;
 }


### PR DESCRIPTION
This fixes the redirect issue, reported here: https://github.com/OpenBB-finance/OpenBB/issues/7210

`/platform/reference/equity/profile` no longer gets replaced as `workspacefile`.