### PR TITLE
[BugFix] Fix ODP Active Tab Style in `/model` & `/reference` Pages

### DIFF
--- a/src/theme/Tabs/index.js
+++ b/src/theme/Tabs/index.js
@@ -72,9 +72,9 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
                 "text-[#669dcb] border-[#669dcb]":
                   selectedValue === value && pathname.startsWith("/workspace"),
                 "text-[#FB923C] border-[#FB923C]":
-                  selectedValue === value && pathname.startsWith("/python"),
+                  selectedValue === value && pathname.startsWith("/odp"),
                 "border-transparent text-grey-400 hover:text-[#ffd4b1] hover:border-[#ffd4b1]":
-                  selectedValue !== value && pathname.startsWith("/python"),
+                  selectedValue !== value && pathname.startsWith("/odp"),
                 "border-transparent text-grey-400 hover:text-[#abd2f1] hover:border-[#abd2f1]":
                   selectedValue !== value && pathname.startsWith("/workspace"),
               },


### PR DESCRIPTION
This PR fixes a casualty of the ODP docs path refactor that was missed - the active tab style.

Before: missing orange color for the selected item.


After:

<img width="2144" height="1348" alt="image" src="https://github.com/user-attachments/assets/0a782834-42b7-4754-ae37-dd1e1e16a4d6" />
