### PR TITLE
Fix/git installation

### DIFF
--- a/content/odp/python/installation.mdx
+++ b/content/odp/python/installation.mdx
@@ -106,6 +106,7 @@ This will mount the local `~/.openbb_platform` directory into the Docker contain
 To install from source, create a Python virtual environment and update `pip` and `setuptools`, within the newly created environment, **before** installing any packages.
 
 <details>
+
 To build the ODP Python packages from the source code, first install `git`:
 
 - macOS (with Homebrew)
@@ -123,7 +124,7 @@ sudo apt install git
 
 Next, clone the repository from GitHub:
 
-- via https
+- via HTTPS
 ```console
 git clone https://github.com/OpenBB-finance/OpenBB.git
 ```

--- a/content/odp/python/installation.mdx
+++ b/content/odp/python/installation.mdx
@@ -108,12 +108,27 @@ To install from source, create a Python virtual environment and update `pip` and
 <details>
 To build the ODP Python packages from the source code, first install `git`:
 
+- macOS (with Homebrew)
 ```console
-pip install git
+brew install git
 ```
+- Ubuntu/Debian:
+
+```console
+sudo apt update
+sudo apt install git
+```
+
+- Windows: Download and install from [git-scm.com/downloads](https://git-scm.com/downloads)
 
 Next, clone the repository from GitHub:
 
+- via https
+```console
+git clone https://github.com/OpenBB-finance/OpenBB.git
+```
+
+- via SSH
 ```console
 git clone git@github.com:OpenBB-finance/OpenBB.git
 ```


### PR DESCRIPTION
Just fixes git installation instructions for specific OS since `pip` doesn't install git (it is not a python package) in `content/odp/python/installation.mdx`. Also added HTTPS for cloning for beginners with no SSH keys.