### PR TITLE
Add openbb-sugra to the Third-Party provider extensions

### DIFF
--- a/content/odp/python/extensions/providers/index.mdx
+++ b/content/odp/python/extensions/providers/index.mdx
@@ -101,6 +101,7 @@ Endpoint and data availability will vary by provider and subscription level, the
 | openbb-intrinio | [Intrinio](https://intrinio.com/pricing) data connector | pip install openbb-intrinio | Paid | intrinio_api_key |
 | openbb-nasdaq | [Nasdaq Data Link](https://data.nasdaq.com/) connector | pip install openbb-nasdaq | None / Free | nasdaq_api_key |
 | openbb-seeking-alpha | [Seeking Alpha](https://seekingalpha.com/) data connector | pip install openbb-seeking-alpha | None | - |
+| openbb-sugra | [Sugra](https://sugra.ai) data connector - 73 OpenBB models from one key | pip install openbb-sugra | Free | sugra_api_key |
 | openbb-tmx | [TMX](https://money.tmx.com) data connector | pip install openbb-tmx | None | - |
 | openbb-tradier | [Tradier](https://tradier.com) data connector | pip install openbb-tradier | None | tradier_api_key; tradier_account_type ('sandbox' or 'live')
 | openbb-tiingo | [Tiingo](https://www.tiingo.com/about/pricing) data connector | pip install openbb-tiingo | Free | tiingo_token |


### PR DESCRIPTION
Adds openbb-sugra to the Third-Party provider extensions table.

openbb-sugra is an Independent Extension published to PyPI and maintained in its own repository. One Sugra API key fulfils 73 OpenBB standard data models across 11 command groups (equity, economy, ETF, currency, fixed income, index, CFTC, commodity, crypto, news, derivatives), all mapped to existing OpenBB standard models and live-verified through the obb.* layer.

- PyPI: https://pypi.org/project/openbb-sugra/
- Repository: https://github.com/Sugra-Systems/openbb-sugra
- Install: pip install openbb-sugra (auto-registers via the openbb_provider_extension entry point)
- Credential: sugra_api_key (free tier available at https://sugra.ai)
- License: AGPL-3.0-only
