### PR TITLE
Add openbb-sugra to Third-Party provider extensions

### DIFF
--- a/content/odp/python/extensions/providers/index.mdx
+++ b/content/odp/python/extensions/providers/index.mdx
@@ -101,6 +101,7 @@ Endpoint and data availability will vary by provider and subscription level, the
 | openbb-intrinio | [Intrinio](https://intrinio.com/pricing) data connector | pip install openbb-intrinio | Paid | intrinio_api_key |
 | openbb-nasdaq | [Nasdaq Data Link](https://data.nasdaq.com/) connector | pip install openbb-nasdaq | None / Free | nasdaq_api_key |
 | openbb-seeking-alpha | [Seeking Alpha](https://seekingalpha.com/) data connector | pip install openbb-seeking-alpha | None | - |
+| openbb-sugra | [Sugra](https://sugra.ai) data connector - 138 OpenBB models from one key | pip install openbb-sugra | Free | sugra_api_key |
 | openbb-tmx | [TMX](https://money.tmx.com) data connector | pip install openbb-tmx | None | - |
 | openbb-tradier | [Tradier](https://tradier.com) data connector | pip install openbb-tradier | None | tradier_api_key; tradier_account_type ('sandbox' or 'live')
 | openbb-tiingo | [Tiingo](https://www.tiingo.com/about/pricing) data connector | pip install openbb-tiingo | Free | tiingo_token |


### PR DESCRIPTION
Adds `openbb-sugra` to the Unofficial Third-Party provider extensions table.

openbb-sugra is a published, independently maintained OpenBB provider extension (AGPL-3.0, https://github.com/Sugra-Systems/openbb-sugra, on PyPI). One Sugra API key fulfils 138 OpenBB standard data models across 14 command groups - equity, economy, fixed income, ETF, currency, index, CFTC, commodity, crypto, news, US Congress, regulators, derivatives, and Fama-French.

This follows the invitation on the page itself: "Have you published a data provider extension and want it featured on this list? Tell us about it! Open a pull request on GitHub to submit an extension for inclusion."

Row added (placed alphabetically in the Third-Party table):

`| openbb-sugra | [Sugra](https://sugra.ai) data connector - 138 OpenBB models from one key | pip install openbb-sugra | Free | sugra_api_key |`

- Install: `pip install openbb-sugra`
- Credential: `sugra_api_key` (free tier available at https://sugra.ai)
- Coverage matrix: https://github.com/Sugra-Systems/openbb-sugra/blob/main/COVERAGE.md

Docs-only change: one row, no code.
